### PR TITLE
refresh jwt in authcontext

### DIFF
--- a/src/api/contexts/auth/AuthContext.tsx
+++ b/src/api/contexts/auth/AuthContext.tsx
@@ -34,7 +34,18 @@ export const AuthContext = createContext<AuthContextType>({
 export const AuthProvider: FC<HasChildren> = ({ children }) => {
   const navigate = useNavigate()
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(typeof Cookies.get(CookieKeys.KONZI_JWT_TOKEN) !== 'undefined')
-  const { isLoading, data: user, error } = useQuery('currentUser', userModule.fetchCurrentUser, { enabled: isLoggedIn })
+  const {
+    isLoading,
+    data: user,
+    error
+  } = useQuery('currentUser', userModule.fetchCurrentUser, {
+    enabled: isLoggedIn,
+    onSuccess: (data) => {
+      if (data.jwt) {
+        Cookies.set(CookieKeys.KONZI_JWT_TOKEN, data.jwt, { expires: 2 })
+      }
+    }
+  })
 
   const onLoginSuccess = (jwt: string) => {
     Cookies.set(CookieKeys.KONZI_JWT_TOKEN, jwt, { expires: 2 })

--- a/src/api/modules/user.module.ts
+++ b/src/api/modules/user.module.ts
@@ -3,7 +3,7 @@ import { UserModel } from '../model/user.model'
 
 class UserModule {
   async fetchCurrentUser() {
-    const response = await axios.get<UserModel>('/users/profile')
+    const response = await axios.get<UserModel & { jwt?: string }>('/users/profile')
     return response.data
   }
 


### PR DESCRIPTION
If the backend sends a new jwt in the response to `/profile` (because the `isAdmin` field has changed), AuthContext updates it in the cookie.
Related to https://github.com/kir-dev/konzisite-api/pull/106