### PR TITLE
Consultation file upload/download

### DIFF
--- a/src/api/hooks/consultationMutationHooks.ts
+++ b/src/api/hooks/consultationMutationHooks.ts
@@ -96,9 +96,9 @@ export const useDeleteFileMutation = (
   )
 }
 
-export const useDownloadFileMutation = (onSuccess: (data: ArrayBuffer) => void, onError: (e: KonziError) => void) => {
-  return useMutation<ArrayBuffer, KonziError, number>(
-    async (consultationId) => (await axios.get(`${PATHS.CONSULTATIONS}/${consultationId}/file`)).data,
+export const useDownloadFileMutation = (onSuccess: (data: ArrayBuffer) => void, onError: () => void) => {
+  return useMutation<ArrayBuffer, ArrayBuffer, number>(
+    async (consultationId) => (await axios.get(`${PATHS.CONSULTATIONS}/${consultationId}/file`, { responseType: 'arraybuffer' })).data,
     {
       onError,
       onSuccess

--- a/src/api/hooks/consultationMutationHooks.ts
+++ b/src/api/hooks/consultationMutationHooks.ts
@@ -67,3 +67,31 @@ export const useUpdateRatingConsultationMutation = (onSuccess: () => void, onErr
     }
   )
 }
+
+export const useUploadFileMutation = (
+  consultationId: number,
+  onSuccess: (data: ConsultationModel) => void,
+  onError: (e: KonziError) => void
+) => {
+  return useMutation<ConsultationModel, KonziError, FormData>(
+    async (data) => (await axios.patch(`${PATHS.CONSULTATIONS}/${consultationId}/file`, data)).data,
+    {
+      onError,
+      onSuccess
+    }
+  )
+}
+
+export const useDeleteFileMutation = (
+  consultationId: number,
+  onSuccess: (data: ConsultationModel) => void,
+  onError: (e: KonziError) => void
+) => {
+  return useMutation<ConsultationModel, KonziError>(
+    async () => (await axios.patch(`${PATHS.CONSULTATIONS}/${consultationId}/deleteFile`)).data,
+    {
+      onError,
+      onSuccess
+    }
+  )
+}

--- a/src/api/hooks/consultationMutationHooks.ts
+++ b/src/api/hooks/consultationMutationHooks.ts
@@ -95,3 +95,13 @@ export const useDeleteFileMutation = (
     }
   )
 }
+
+export const useDownloadFileMutation = (onSuccess: (data: ArrayBuffer) => void, onError: (e: KonziError) => void) => {
+  return useMutation<ArrayBuffer, KonziError, number>(
+    async (consultationId) => (await axios.get(`${PATHS.CONSULTATIONS}/${consultationId}/file`)).data,
+    {
+      onError,
+      onSuccess
+    }
+  )
+}

--- a/src/components/commons/UploadFileModalButton.tsx
+++ b/src/components/commons/UploadFileModalButton.tsx
@@ -25,7 +25,6 @@ type Props = {
   fileIcon: ReactElement
   extraButton?: ReactNode
   disabled?: boolean
-  buttonWidth?: string
 }
 
 export const UploadFileModalButton = ({
@@ -36,8 +35,7 @@ export const UploadFileModalButton = ({
   extraButton,
   accept,
   fileIcon,
-  disabled = false,
-  buttonWidth
+  disabled = false
 }: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const methods = useForm<{ files: FileList | undefined }>({ mode: 'all' })

--- a/src/components/commons/UploadFileModalButton.tsx
+++ b/src/components/commons/UploadFileModalButton.tsx
@@ -10,22 +10,35 @@ import {
   Spacer,
   useDisclosure
 } from '@chakra-ui/react'
-import { ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
-import { FaFileCsv } from 'react-icons/fa'
 import { UseMutationResult } from 'react-query'
-import { KonziError } from '../../../api/model/error.model'
-import { FileUpload } from '../../../components/form-elements/FileUpload'
+import { KonziError } from '../../api/model/error.model'
+import { FileUpload } from '../form-elements/FileUpload'
 
 type Props = {
   mutation: UseMutationResult<unknown, KonziError, FormData, unknown>
   modalTitle: string
   confirmButtonText: string
   children: ReactNode
+  accept: string
+  fileIcon: ReactElement
   extraButton?: ReactNode
+  disabled?: boolean
+  buttonWidth?: string
 }
 
-export const UploadFileModalButton = ({ mutation, modalTitle, confirmButtonText, children, extraButton }: Props) => {
+export const UploadFileModalButton = ({
+  mutation,
+  modalTitle,
+  confirmButtonText,
+  children,
+  extraButton,
+  accept,
+  fileIcon,
+  disabled = false,
+  buttonWidth
+}: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const methods = useForm<{ files: FileList | undefined }>({ mode: 'all' })
   const {
@@ -41,6 +54,7 @@ export const UploadFileModalButton = ({ mutation, modalTitle, confirmButtonText,
       mutation.mutate(formData, {
         onSuccess: () => {
           onClose()
+          reset()
         }
       })
     }
@@ -53,7 +67,7 @@ export const UploadFileModalButton = ({ mutation, modalTitle, confirmButtonText,
 
   return (
     <>
-      <Button colorScheme="green" onClick={onOpen}>
+      <Button colorScheme="green" onClick={onOpen} isDisabled={disabled}>
         {modalTitle}
       </Button>
       <Modal isOpen={isOpen} onClose={onCancelPressed} size="xl">
@@ -66,7 +80,7 @@ export const UploadFileModalButton = ({ mutation, modalTitle, confirmButtonText,
               <ModalBody>
                 {children}
 
-                <FileUpload required fieldName="files" buttonIcon={<FaFileCsv />} accept=".csv" />
+                <FileUpload required fieldName="files" buttonIcon={fileIcon} accept={accept} />
               </ModalBody>
               <ModalFooter>
                 {extraButton}

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -170,9 +170,14 @@ export const ConsultationDetailsPage = () => {
                   disabled={consultation.archived}
                   extraButton={
                     consultation.fileName && (
-                      <Button colorScheme="red" onClick={() => deleteFileFromConsultation()}>
-                        Jegyzet törlése
-                      </Button>
+                      <ConfirmDialogButton
+                        bodyText="Biztosan törlöd a feltöltött fájlt? A résztvevők ezentúl nem fogják tudni letölteni."
+                        confirmAction={() => deleteFileFromConsultation()}
+                        headerText="Jegyzet törlése"
+                        buttonText="Jegyzet törlése"
+                        confirmButtonText="Törlés"
+                        buttonColorSchene="red"
+                      />
                     )
                   }
                 >

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -223,8 +223,7 @@ export const ConsultationDetailsPage = () => {
               />
             </>
           )}
-          {(isPresenter || isOwner || isAdmin || isParticipant) &&
-            new Date() > new Date(consultation.startDate) &&
+          {((new Date() > new Date(consultation.startDate) && isParticipant) || isPresenter || isOwner || isAdmin) &&
             consultation.fileName && (
               <>
                 <a ref={downloadRef} download={consultation.fileName} hidden />

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -168,7 +168,6 @@ export const ConsultationDetailsPage = () => {
                   accept=".jpg,.jpeg,.png,.pdf,.docx,.pptx,.zip,.txt"
                   fileIcon={<FaFileUpload />}
                   disabled={consultation.archived}
-                  buttonWidth="100%"
                   extraButton={
                     consultation.fileName && (
                       <Button colorScheme="red" onClick={() => deleteFileFromConsultation()}>

--- a/src/pages/consultations/EditConsultationPage.tsx
+++ b/src/pages/consultations/EditConsultationPage.tsx
@@ -157,7 +157,7 @@ export const EditConsultationPage = ({ newConsultation }: Props) => {
                   formDetails={{
                     id: 'descMarkdown',
                     promptText: '',
-                    maxChar: 1000
+                    maxChar: 5000
                   }}
                   textAreaHeight="8rem"
                   previewHeight="12rem"

--- a/src/pages/subjects/SubjectsPage.tsx
+++ b/src/pages/subjects/SubjectsPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react'
 import { useState } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { FaEdit } from 'react-icons/fa'
+import { FaEdit, FaFileCsv } from 'react-icons/fa'
 import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
 import {
   useCreateSubjectMutation,
@@ -26,11 +26,11 @@ import {
   useUpdateSubjectMutation
 } from '../../api/hooks/subjectHooks'
 import { KonziError } from '../../api/model/error.model'
+import { UploadFileModalButton } from '../../components/commons/UploadFileModalButton'
 import { generateToastParams } from '../../util/generateToastParams'
 import { ErrorPage } from '../error/ErrorPage'
 import { MajorBadge } from './components/MajorBadge'
 import { SubjectEditModalButton } from './components/SubjectEditModalButton'
-import { UploadFileModalButton } from './components/UploadFileModalButton'
 import { MajorArray, translateMajor } from './util/majorHelpers'
 
 export const SubjectsPage = () => {
@@ -84,6 +84,8 @@ export const SubjectsPage = () => {
             mutation={importSubjectsmutation}
             modalTitle="Tárgyak importálása"
             confirmButtonText="Importálás"
+            accept=".csv"
+            fileIcon={<FaFileCsv />}
             extraButton={
               <a href="example_import.csv" download>
                 <Button colorScheme="green">Minta fájl letöltése</Button>


### PR DESCRIPTION
Presenters/Owners/Admins can upload a file to the consultation. They can download it whenever they want to, and participants can download it after the konzi has started and they have rated at least one presenter.  If the konzi is archived, no one can upload or download anymore, the buttons get disabled.

We need to do something about the design of the buttons (I wasn't focusing on the design in this pr at all), we should probably put all the options into a dropdown menu.

Related to #50, but doesn't complete it