### PR TITLE
konzi details buttons & download button refactor

### DIFF
--- a/src/api/hooks/consultationMutationHooks.ts
+++ b/src/api/hooks/consultationMutationHooks.ts
@@ -96,12 +96,14 @@ export const useDeleteFileMutation = (
   )
 }
 
-export const useDownloadFileMutation = (onSuccess: (data: ArrayBuffer) => void, onError: () => void) => {
+export const useDownloadFileMutation = () => {
   return useMutation<ArrayBuffer, ArrayBuffer, number>(
-    async (consultationId) => (await axios.get(`${PATHS.CONSULTATIONS}/${consultationId}/file`, { responseType: 'arraybuffer' })).data,
-    {
-      onError,
-      onSuccess
-    }
+    async (consultationId) => (await axios.get(`${PATHS.CONSULTATIONS}/${consultationId}/file`, { responseType: 'arraybuffer' })).data
+  )
+}
+
+export const useExportConsultationMutation = () => {
+  return useMutation<ArrayBuffer, ArrayBuffer, number>( // TODO finalize url when it's done on the backend
+    async (consultationId) => (await axios.get(`${PATHS.CONSULTATIONS}/${consultationId}/export`, { responseType: 'arraybuffer' })).data
   )
 }

--- a/src/components/commons/ConfirmDialogButton.tsx
+++ b/src/components/commons/ConfirmDialogButton.tsx
@@ -9,27 +9,25 @@ import {
   Button,
   useDisclosure
 } from '@chakra-ui/react'
-import { useRef } from 'react'
+import { ReactElement, RefObject, useEffect, useRef } from 'react'
 
 interface ConfirmDialogButtonProps {
   headerText?: string
   bodyText?: string
-  buttonText?: string
-  buttonColorSchene?: string
-  buttonVariant?: string
+  initiatorButton: ReactElement
+  initiatorButtonRef: RefObject<HTMLButtonElement>
+  buttonColorScheme?: string
   confirmButtonText?: string
   refuseButtonText?: string
-  buttonWidth?: string
   confirmAction: () => void
 }
 
 export const ConfirmDialogButton = ({
   headerText,
   bodyText,
-  buttonText = '',
-  buttonColorSchene,
-  buttonVariant,
-  buttonWidth,
+  initiatorButton,
+  initiatorButtonRef,
+  buttonColorScheme = 'red',
   confirmButtonText = 'Igen',
   refuseButtonText = 'Mégse',
   confirmAction
@@ -37,11 +35,15 @@ export const ConfirmDialogButton = ({
   const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = useRef(null)
 
+  useEffect(() => {
+    if (initiatorButtonRef?.current) {
+      initiatorButtonRef.current.onclick = onOpen
+    }
+  }, [])
+
   return (
     <>
-      <Button onClick={onOpen} width={buttonWidth} colorScheme={buttonColorSchene} variant={buttonVariant}>
-        {buttonText}
-      </Button>
+      {initiatorButton}
       <AlertDialog
         preserveScrollBarGap={true}
         motionPreset="slideInBottom"
@@ -59,7 +61,7 @@ export const ConfirmDialogButton = ({
             <Button ref={cancelRef} onClick={onClose}>
               {refuseButtonText}
             </Button>
-            <Button colorScheme={buttonColorSchene} ml={3} onClick={confirmAction}>
+            <Button colorScheme={buttonColorScheme} ml={3} onClick={confirmAction}>
               {confirmButtonText}
             </Button>
           </AlertDialogFooter>

--- a/src/components/commons/DownloadFileFromServerButton.tsx
+++ b/src/components/commons/DownloadFileFromServerButton.tsx
@@ -1,0 +1,45 @@
+import { useToast } from '@chakra-ui/react'
+import { RefObject, useEffect, useRef } from 'react'
+import { UseMutationResult } from 'react-query'
+import { HasChildren } from '../../util/react-types.util'
+
+type Props = {
+  buttonRef: RefObject<HTMLButtonElement>
+  downloadMutation: UseMutationResult<ArrayBuffer, ArrayBuffer, number, unknown>
+  entityId: number
+  fileName: string
+} & HasChildren
+
+export const DownloadFileFromServerButton = ({ buttonRef, downloadMutation, entityId, children, fileName }: Props) => {
+  const anchorRef = useRef<HTMLAnchorElement>(null)
+  const toast = useToast()
+
+  useEffect(() => {
+    if (buttonRef?.current) {
+      buttonRef.current.onclick = () => {
+        downloadMutation.mutate(entityId, {
+          onSuccess: (rawFile: ArrayBuffer) => {
+            const blob = new Blob([rawFile])
+            if (anchorRef.current) {
+              anchorRef.current.href = URL.createObjectURL(blob)
+              anchorRef.current.click()
+            }
+          },
+          onError: () => {
+            toast({
+              title: 'Hiba a fájl letöltése közben',
+              description: 'Lehet hogy már törlésre került, vagy nincs jogod megtekinteni.',
+              status: 'error'
+            })
+          }
+        })
+      }
+    }
+  }, [])
+  return (
+    <>
+      <a ref={anchorRef} download={fileName} hidden />
+      {children}
+    </>
+  )
+}

--- a/src/components/commons/UploadFileModalButton.tsx
+++ b/src/components/commons/UploadFileModalButton.tsx
@@ -10,7 +10,7 @@ import {
   Spacer,
   useDisclosure
 } from '@chakra-ui/react'
-import { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode, RefObject, useEffect } from 'react'
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form'
 import { UseMutationResult } from 'react-query'
 import { KonziError } from '../../api/model/error.model'
@@ -23,8 +23,9 @@ type Props = {
   children: ReactNode
   accept: string
   fileIcon: ReactElement
+  initiatorButton: ReactElement
+  initiatorButtonRef: RefObject<HTMLButtonElement>
   extraButton?: ReactNode
-  disabled?: boolean
 }
 
 export const UploadFileModalButton = ({
@@ -35,7 +36,8 @@ export const UploadFileModalButton = ({
   extraButton,
   accept,
   fileIcon,
-  disabled = false
+  initiatorButton,
+  initiatorButtonRef
 }: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const methods = useForm<{ files: FileList | undefined }>({ mode: 'all' })
@@ -57,6 +59,11 @@ export const UploadFileModalButton = ({
       })
     }
   }
+  useEffect(() => {
+    if (initiatorButtonRef?.current) {
+      initiatorButtonRef.current.onclick = onOpen
+    }
+  }, [])
 
   const onCancelPressed = () => {
     onClose()
@@ -65,9 +72,7 @@ export const UploadFileModalButton = ({
 
   return (
     <>
-      <Button colorScheme="green" onClick={onOpen} isDisabled={disabled}>
-        {modalTitle}
-      </Button>
+      {initiatorButton}
       <Modal isOpen={isOpen} onClose={onCancelPressed} size="xl">
         <ModalOverlay />
         <ModalContent>

--- a/src/components/editor/editorUtils.ts
+++ b/src/components/editor/editorUtils.ts
@@ -1,1 +1,1 @@
-export const getStatusString = (text: string = '', maxChar: number): string => `${text.length} / ${maxChar}`
+export const getStatusString = (text: string = '', maxChar: number): string => `${text?.length || 0} / ${maxChar}`

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -190,7 +190,7 @@ export const ConsultationDetailsPage = () => {
         columns={1}
         users={consultation.presentations}
         isParticipant={isParticipant}
-        showRatingButton={new Date(consultation.startDate).getTime() < new Date().getTime()}
+        showRatingButton={new Date(consultation.startDate) < new Date() && isParticipant}
         refetch={refetch}
       />
       <TargetGroupList groups={consultation.targetGroups} />

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom'
 import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
 import {
   useDownloadFileMutation,
-  useExportConsultationMutation,
+  //useExportConsultationMutation,
   useJoinConsultationMutation,
   useLeaveConsultationMutation
 } from '../../api/hooks/consultationMutationHooks'
@@ -29,7 +29,7 @@ export const ConsultationDetailsPage = () => {
   const { isLoading, data: consultation, error, refetch } = useFetchConsultationbDetailsQuery(+consultationId!!)
   const toast = useToast()
   const downloadFileRef = useRef<HTMLButtonElement>(null)
-  const exportKonziRef = useRef<HTMLButtonElement>(null)
+  //const exportKonziRef = useRef<HTMLButtonElement>(null)
 
   const onErrorFn = (e: KonziError) => {
     toast(generateToastParams(e))
@@ -46,7 +46,7 @@ export const ConsultationDetailsPage = () => {
   }, onErrorFn)
 
   const downloadFileMutation = useDownloadFileMutation()
-  const exportKonziMutation = useExportConsultationMutation()
+  //const exportKonziMutation = useExportConsultationMutation()
 
   if (!consultationId || !isValidId(consultationId)) {
     return <ErrorPage backPath={PATHS.CONSULTATIONS} status={404} title={'A konzultáció nem található!'} />
@@ -163,7 +163,7 @@ export const ConsultationDetailsPage = () => {
                 </Tooltip>
               </DownloadFileFromServerButton>
             )}
-          {new Date() < new Date(consultation.startDate) && (
+          {/*new Date() < new Date(consultation.startDate) && (   // TODO remove comment when the backend is ready
             <DownloadFileFromServerButton
               buttonRef={exportKonziRef}
               downloadMutation={exportKonziMutation}
@@ -174,7 +174,7 @@ export const ConsultationDetailsPage = () => {
                 Exportálás naptárba
               </Button>
             </DownloadFileFromServerButton>
-          )}
+          )*/}
           {(isOwner || isAdmin || isPresenter) && <ConsultationAdminActions refetch={refetch} consultation={consultation} />}
         </VStack>
       </Stack>

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -1,7 +1,23 @@
-import { Alert, AlertIcon, Box, Button, Heading, HStack, Stack, Text, Tooltip, useToast, VStack } from '@chakra-ui/react'
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Stack,
+  Text,
+  Tooltip,
+  useToast,
+  VStack
+} from '@chakra-ui/react'
 import { useRef } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { FaClock, FaFileUpload, FaMapMarkerAlt } from 'react-icons/fa'
+import { FaChevronDown, FaClock, FaEdit, FaFileUpload, FaMapMarkerAlt, FaTrash } from 'react-icons/fa'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
 import {
@@ -32,6 +48,10 @@ export const ConsultationDetailsPage = () => {
   const toast = useToast()
   const navigate = useNavigate()
   const downloadRef = useRef<HTMLAnchorElement>(null)
+  const uploadModalRef = useRef<HTMLButtonElement>(null)
+  const deleteKonziRef = useRef<HTMLButtonElement>(null)
+  const deleteFileFromKonziRef = useRef<HTMLButtonElement>(null)
+  const leaveKonziRef = useRef<HTMLButtonElement>(null)
 
   const onErrorFn = (e: KonziError) => {
     toast(generateToastParams(e))
@@ -152,56 +172,76 @@ export const ConsultationDetailsPage = () => {
         <VStack justify={['center', 'flex-end']} align="flex-end">
           {(isOwner || isAdmin || isPresenter) && (
             <>
-              <Button width="100%" as={Link} to={`${PATHS.CONSULTATIONS}/${consultation.id}/edit`} colorScheme="brand">
-                Szerkesztés
-              </Button>
-              <Tooltip
-                label={consultation.archived ? 'A konzi archiválva lett, már nem lehet feltölteni fájlt.' : ''}
-                placement="left"
-                hasArrow
-                shouldWrapChildren
-              >
-                <UploadFileModalButton
-                  modalTitle={consultation.fileName ? 'Jegyzet szerkesztése' : 'Jegyzet feltöltése'}
-                  confirmButtonText="Mentés"
-                  mutation={uploadFileMutation}
-                  accept=".jpg,.jpeg,.png,.pdf,.docx,.pptx,.zip,.txt"
-                  fileIcon={<FaFileUpload />}
-                  disabled={consultation.archived}
-                  extraButton={
-                    consultation.fileName && (
-                      <ConfirmDialogButton
-                        bodyText="Biztosan törlöd a feltöltött fájlt? A résztvevők ezentúl nem fogják tudni letölteni."
-                        confirmAction={() => deleteFileFromConsultation()}
-                        headerText="Jegyzet törlése"
-                        buttonText="Jegyzet törlése"
-                        confirmButtonText="Törlés"
-                        buttonColorSchene="red"
-                      />
-                    )
-                  }
-                >
-                  <Text textAlign="justify">
-                    Előadóként vagy létrehozóként van lehetőséged egy fájl feltöltésére a konzihoz. Ezt a fájlt a konzi résztvevői a konzi
-                    kezdete után tudják letölteni, ha már értékelték az előadókat.
-                  </Text>
-                  <Text as="b">Megengedett fájlformátumok: .jpg, .png, .pdf, .docx, .pptx, .zip</Text>
-                  <br />
-                  <Text as="b">Maximális fájlméret: 10 MB</Text>
-                  <Alert my={2} status="warning">
-                    <AlertIcon />A fájl a konzi vége után 30 nappal törlődik a szerverről, és nem lesz többé letölthető!
-                  </Alert>
-                </UploadFileModalButton>
-              </Tooltip>
-              <ConfirmDialogButton
-                buttonColorSchene="red"
-                buttonText="Törlés"
-                buttonWidth="100%"
-                headerText="Konzultáció törlése"
-                bodyText="Biztos törölni szeretnéd a konzultációt?"
-                confirmButtonText="Törlés"
-                confirmAction={() => deleteConsultation(+consultationId)}
-              />
+              <Menu>
+                <MenuButton as={Button} colorScheme="brand" rightIcon={<FaChevronDown />}>
+                  Műveletek
+                </MenuButton>
+                <MenuList>
+                  <MenuItem color="blue" as={Link} to={`${PATHS.CONSULTATIONS}/${consultation.id}/edit`} icon={<FaEdit />}>
+                    Szerkesztés
+                  </MenuItem>
+
+                  <Tooltip
+                    label={consultation.archived ? 'A konzi archiválva lett, már nem lehet feltölteni fájlt.' : ''}
+                    placement="left"
+                    hasArrow
+                    shouldWrapChildren
+                  >
+                    <UploadFileModalButton
+                      initiatorButton={
+                        <MenuItem color="green" ref={uploadModalRef} icon={<FaFileUpload />} disabled={consultation.archived}>
+                          {consultation.fileName ? 'Jegyzet módosítása' : 'Jegyzet feltöltése'}
+                        </MenuItem>
+                      }
+                      initiatorButtonRef={uploadModalRef}
+                      modalTitle={consultation.fileName ? 'Jegyzet módosítása' : 'Jegyzet feltöltése'}
+                      confirmButtonText="Mentés"
+                      mutation={uploadFileMutation}
+                      accept=".jpg,.jpeg,.png,.pdf,.docx,.pptx,.zip,.txt"
+                      fileIcon={<FaFileUpload />}
+                      extraButton={
+                        consultation.fileName && (
+                          <ConfirmDialogButton
+                            initiatorButton={
+                              <Button ref={deleteFileFromKonziRef} colorScheme="red">
+                                Jegyzet törlése
+                              </Button>
+                            }
+                            initiatorButtonRef={deleteFileFromKonziRef}
+                            bodyText="Biztosan törlöd a feltöltött fájlt? A résztvevők ezentúl nem fogják tudni letölteni."
+                            confirmAction={() => deleteFileFromConsultation()}
+                            headerText="Jegyzet törlése"
+                            confirmButtonText="Törlés"
+                          />
+                        )
+                      }
+                    >
+                      <Text textAlign="justify">
+                        Előadóként vagy létrehozóként van lehetőséged egy fájl feltöltésére a konzihoz. Ezt a fájlt a konzi résztvevői a
+                        konzi kezdete után tudják letölteni, ha már értékelték az előadókat.
+                      </Text>
+                      <Text as="b">Megengedett fájlformátumok: .jpg, .png, .pdf, .docx, .pptx, .zip</Text>
+                      <br />
+                      <Text as="b">Maximális fájlméret: 10 MB</Text>
+                      <Alert rounded="md" my={2} status="warning">
+                        <AlertIcon />A fájl a konzi vége után 30 nappal törlődik a szerverről, és nem lesz többé letölthető!
+                      </Alert>
+                    </UploadFileModalButton>
+                  </Tooltip>
+                  <ConfirmDialogButton
+                    initiatorButton={
+                      <MenuItem color="red" ref={deleteKonziRef} icon={<FaTrash />}>
+                        Törlés
+                      </MenuItem>
+                    }
+                    initiatorButtonRef={deleteKonziRef}
+                    headerText="Konzultáció törlése"
+                    bodyText="Biztos törölni szeretnéd a konzultációt?"
+                    confirmButtonText="Törlés"
+                    confirmAction={() => deleteConsultation(+consultationId)}
+                  />
+                </MenuList>
+              </Menu>
             </>
           )}
           {!isPresenter && !isParticipant && !isOwner && (
@@ -217,8 +257,12 @@ export const ConsultationDetailsPage = () => {
           {isParticipant && !ratedConsultation && (
             <>
               <ConfirmDialogButton
-                buttonText="Mégsem megyek"
-                buttonColorSchene="red"
+                initiatorButton={
+                  <Button colorScheme="red" ref={leaveKonziRef}>
+                    Mégsem megyek
+                  </Button>
+                }
+                initiatorButtonRef={leaveKonziRef}
                 headerText="Biztos nem mész a konzira?"
                 confirmButtonText="Nem megyek"
                 confirmAction={() => {
@@ -253,6 +297,9 @@ export const ConsultationDetailsPage = () => {
                 </Tooltip>
               </>
             )}
+          {new Date() < new Date(consultation.startDate) &&
+            // TODO .ics fájl letöltő gomb
+            false}
         </VStack>
       </Stack>
       {consultation.descMarkdown && (

--- a/src/pages/consultations/EditConsultationPage.tsx
+++ b/src/pages/consultations/EditConsultationPage.tsx
@@ -1,8 +1,9 @@
-import { Button, FormControl, FormErrorMessage, FormLabel, Heading, Input, useToast, VStack } from '@chakra-ui/react'
+import { Button, Flex, FormControl, FormErrorMessage, FormLabel, Heading, Input, useToast, VStack } from '@chakra-ui/react'
 import { useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { FormProvider, useForm } from 'react-hook-form'
-import { useNavigate, useParams } from 'react-router-dom'
+import { FaArrowLeft } from 'react-icons/fa'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
 import { useCreateConsultationMutation, useEditConsultationMutation } from '../../api/hooks/consultationMutationHooks'
 import { useFetchConsultationbDetailsQuery } from '../../api/hooks/consultationQueryHooks'
@@ -151,6 +152,7 @@ export const EditConsultationPage = ({ newConsultation }: Props) => {
               <SubjectSelector />
               <PresentersSelector />
               <ConsultationDateForm prevStartDate={consultation && new Date(consultation.startDate)} />
+              <TargetGroupSelector />
               <FormControl>
                 <FormLabel>Leírás</FormLabel>
                 <MarkdownEditor
@@ -163,19 +165,26 @@ export const EditConsultationPage = ({ newConsultation }: Props) => {
                   previewHeight="12rem"
                 />
               </FormControl>
-              <TargetGroupSelector />
             </FormProvider>
           </VStack>
-          <Button
-            mt={3}
-            colorScheme="brand"
-            onClick={() => {
-              onSubmit()
-            }}
-            isDisabled={!isValid && isSubmitted}
-          >
-            {newConsultation ? 'Létrehozás' : 'Mentés'}
-          </Button>
+          <Flex mt={1} justify="space-between">
+            <Button
+              leftIcon={<FaArrowLeft />}
+              as={Link}
+              to={newConsultation ? PATHS.CONSULTATIONS : `${PATHS.CONSULTATIONS}/${consultationId}`}
+            >
+              Vissza
+            </Button>
+            <Button
+              colorScheme="brand"
+              onClick={() => {
+                onSubmit()
+              }}
+              isDisabled={!isValid && isSubmitted}
+            >
+              {newConsultation ? 'Létrehozás' : 'Mentés'}
+            </Button>
+          </Flex>
         </>
       )}
     </>

--- a/src/pages/consultations/components/ConsultationAdminActions.tsx
+++ b/src/pages/consultations/components/ConsultationAdminActions.tsx
@@ -1,0 +1,137 @@
+import {
+  Alert,
+  AlertIcon,
+  Button,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+  Tooltip,
+  useColorModeValue,
+  useToast
+} from '@chakra-ui/react'
+import { useRef } from 'react'
+import { FaChevronDown, FaEdit, FaFileUpload, FaTrash } from 'react-icons/fa'
+import { Link, useNavigate } from 'react-router-dom'
+import { useDeleteConsultationMutation, useDeleteFileMutation, useUploadFileMutation } from '../../../api/hooks/consultationMutationHooks'
+import { KonziError } from '../../../api/model/error.model'
+import { ConfirmDialogButton } from '../../../components/commons/ConfirmDialogButton'
+import { UploadFileModalButton } from '../../../components/commons/UploadFileModalButton'
+import { generateToastParams } from '../../../util/generateToastParams'
+import { PATHS } from '../../../util/paths'
+import { ConsultationDetails } from '../types/consultationDetails'
+
+type Props = {
+  consultation: ConsultationDetails
+  refetch: () => void
+}
+
+export const ConsultationAdminActions = ({ consultation, refetch }: Props) => {
+  const uploadModalRef = useRef<HTMLButtonElement>(null)
+  const deleteKonziRef = useRef<HTMLButtonElement>(null)
+  const deleteFileFromKonziRef = useRef<HTMLButtonElement>(null)
+  const navigate = useNavigate()
+  const toast = useToast()
+  const editTextColor = useColorModeValue('brand.500', 'brand.200')
+
+  const onErrorFn = (e: KonziError) => {
+    toast(generateToastParams(e))
+  }
+
+  const { mutate: deleteConsultation } = useDeleteConsultationMutation(() => {
+    toast({ title: 'Törölted a konzultációt!', status: 'success' })
+    navigate(PATHS.CONSULTATIONS)
+  }, onErrorFn)
+
+  const uploadFileMutation = useUploadFileMutation(
+    consultation.id,
+    () => {
+      toast({ title: 'Jegyzet feltöltve!', status: 'success' })
+      refetch()
+    },
+    onErrorFn
+  )
+
+  const { mutate: deleteFileFromConsultation } = useDeleteFileMutation(
+    consultation.id,
+    () => {
+      toast({ title: 'Törölted a jegyzetet!', status: 'success' })
+      refetch()
+    },
+    onErrorFn
+  )
+
+  return (
+    <Menu>
+      <MenuButton as={Button} w="100%" colorScheme="brand" rightIcon={<FaChevronDown />}>
+        Műveletek
+      </MenuButton>
+      <MenuList>
+        <MenuItem color={editTextColor} as={Link} to={`${PATHS.CONSULTATIONS}/${consultation.id}/edit`} icon={<FaEdit />}>
+          Szerkesztés
+        </MenuItem>
+
+        <Tooltip
+          label={consultation.archived ? 'A konzi archiválva lett, már nem lehet feltölteni fájlt.' : ''}
+          placement="left"
+          hasArrow
+          shouldWrapChildren
+        >
+          <UploadFileModalButton
+            initiatorButton={
+              <MenuItem color="green" ref={uploadModalRef} icon={<FaFileUpload />} isDisabled={consultation.archived}>
+                {consultation.fileName ? 'Jegyzet módosítása' : 'Jegyzet feltöltése'}
+              </MenuItem>
+            }
+            initiatorButtonRef={uploadModalRef}
+            modalTitle={consultation.fileName ? 'Jegyzet módosítása' : 'Jegyzet feltöltése'}
+            confirmButtonText="Mentés"
+            mutation={uploadFileMutation}
+            accept=".jpg,.jpeg,.png,.pdf,.docx,.pptx,.zip,.txt"
+            fileIcon={<FaFileUpload />}
+            extraButton={
+              consultation.fileName && (
+                <ConfirmDialogButton
+                  initiatorButton={
+                    <Button ref={deleteFileFromKonziRef} colorScheme="red">
+                      Jegyzet törlése
+                    </Button>
+                  }
+                  initiatorButtonRef={deleteFileFromKonziRef}
+                  bodyText="Biztosan törlöd a feltöltött fájlt? A résztvevők ezentúl nem fogják tudni letölteni."
+                  confirmAction={() => deleteFileFromConsultation()}
+                  headerText="Jegyzet törlése"
+                  confirmButtonText="Törlés"
+                />
+              )
+            }
+          >
+            <Text textAlign="justify">
+              Előadóként vagy létrehozóként van lehetőséged egy fájl feltöltésére a konzihoz. Ezt a fájlt a konzi résztvevői a konzi kezdete
+              után tudják letölteni, ha már értékelték az előadókat.
+            </Text>
+            <Text as="b">Megengedett fájlformátumok: .jpg, .png, .pdf, .docx, .pptx, .zip</Text>
+            <br />
+            <Text as="b">Maximális fájlméret: 10 MB</Text>
+            <Alert rounded="md" my={2} status="warning">
+              <AlertIcon />A fájl a konzi vége után 30 nappal törlődik a szerverről, és nem lesz többé letölthető!
+            </Alert>
+          </UploadFileModalButton>
+        </Tooltip>
+        <ConfirmDialogButton
+          initiatorButton={
+            <MenuItem color="red" ref={deleteKonziRef} icon={<FaTrash />}>
+              Törlés
+            </MenuItem>
+          }
+          initiatorButtonRef={deleteKonziRef}
+          headerText="Konzultáció törlése"
+          bodyText="Biztos törölni szeretnéd a konzultációt?"
+          confirmButtonText="Törlés"
+          confirmAction={() => deleteConsultation(consultation.id)}
+        />
+      </MenuList>
+    </Menu>
+  )
+}

--- a/src/pages/consultations/components/PresentersSelector.tsx
+++ b/src/pages/consultations/components/PresentersSelector.tsx
@@ -109,7 +109,7 @@ export const PresentersSelector = () => {
           <Box borderRadius={6} borderWidth={1} mb={2} key={p.id}>
             <HStack flexGrow={1} p={4}>
               <Avatar size="md" name={p.fullName} src={''} />
-              <VStack flexGrow={1}>
+              <VStack alignItems="flex-start" flexGrow={1}>
                 <Heading size="md" width="100%">
                   {p.fullName}
                   {p.id === loggedInUser.id && (
@@ -189,7 +189,7 @@ export const PresentersSelector = () => {
                   >
                     <HStack flexGrow={1} p={4}>
                       <Avatar size="md" name={p.fullName} src={''} />
-                      <VStack flexGrow={1}>
+                      <VStack alignItems="flex-start" flexGrow={1}>
                         <Heading size="md" width="100%">
                           {p.fullName}
                           {p.id === loggedInUser.id && (

--- a/src/pages/consultations/components/UserList.tsx
+++ b/src/pages/consultations/components/UserList.tsx
@@ -53,7 +53,9 @@ export const UserList = ({ users, isParticipant, columns, showRating = true, sho
                   )}
                 </VStack>
               </HStack>
-              {showRating && <UserRating showRatingButton={showRatingButton} isParticipant={isParticipant} refetch={refetch} user={u} />}
+              {showRatingButton && (
+                <UserRating showRatingButton={showRatingButton} isParticipant={isParticipant} refetch={refetch} user={u} />
+              )}
             </Stack>
           </Box>
         ))}

--- a/src/pages/consultations/components/UserRating.tsx
+++ b/src/pages/consultations/components/UserRating.tsx
@@ -17,6 +17,7 @@ import {
   SliderTrack,
   Text,
   Textarea,
+  Tooltip,
   useToast,
   VStack
 } from '@chakra-ui/react'
@@ -97,19 +98,21 @@ export const UserRating = ({ isParticipant, user, showRatingButton, refetch }: P
           </>
         )}
         {isParticipant && !user.rating && (
-          <Button
-            width="100%"
-            colorScheme="brand"
-            isDisabled={!showRatingButton}
-            onClick={() => {
-              setText('')
-              setValue(5)
-              setAnonymous(false)
-              setOpen(true)
-            }}
-          >
-            Értékelés
-          </Button>
+          <Tooltip label={showRatingButton ? '' : 'A konzi kezdete után tudod értékelni az előadót.'} placement="left" hasArrow>
+            <Button
+              width="100%"
+              colorScheme="brand"
+              isDisabled={!showRatingButton}
+              onClick={() => {
+                setText('')
+                setValue(5)
+                setAnonymous(false)
+                setOpen(true)
+              }}
+            >
+              Értékelés
+            </Button>
+          </Tooltip>
         )}
       </VStack>
       <Modal isCentered motionPreset="slideInBottom" isOpen={open} onClose={() => setOpen(false)}>

--- a/src/pages/groups/components/GroupOptionsButton.tsx
+++ b/src/pages/groups/components/GroupOptionsButton.tsx
@@ -1,4 +1,5 @@
 import { Button, useToast } from '@chakra-ui/react'
+import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   useDeleteGroupMutation,
@@ -22,6 +23,8 @@ type props = {
 export const GroupOptionsButton = ({ group, refetchDetails }: props) => {
   const toast = useToast()
   const navigate = useNavigate()
+  const deleteGroupRef = useRef<HTMLButtonElement>(null)
+  const leaveGroupRef = useRef<HTMLButtonElement>(null)
 
   const onErrorFn = (e: KonziError) => {
     toast(generateToastParams(e))
@@ -74,9 +77,12 @@ export const GroupOptionsButton = ({ group, refetchDetails }: props) => {
             previousName={group.name}
           />
           <ConfirmDialogButton
-            buttonColorSchene="red"
-            buttonWidth="100%"
-            buttonText="Törlés"
+            initiatorButton={
+              <Button w="100%" ref={deleteGroupRef} colorScheme="red">
+                Törlés
+              </Button>
+            }
+            initiatorButtonRef={deleteGroupRef}
             headerText="Csoport törlése"
             bodyText="Biztos törölni szeretnéd a csoportot?"
             confirmButtonText="Törlés"
@@ -88,9 +94,12 @@ export const GroupOptionsButton = ({ group, refetchDetails }: props) => {
     case GroupRoles.MEMBER:
       return (
         <ConfirmDialogButton
-          buttonColorSchene="red"
-          buttonWidth="100%"
-          buttonText="Kilépés"
+          initiatorButton={
+            <Button w="100%" ref={leaveGroupRef} colorScheme="red">
+              Kilépés
+            </Button>
+          }
+          initiatorButtonRef={leaveGroupRef}
           headerText="Kilépés a csoportból"
           bodyText="Biztos ki szeretnél lépni a csoportból?"
           confirmButtonText="Kilépés"

--- a/src/pages/groups/components/UserList.tsx
+++ b/src/pages/groups/components/UserList.tsx
@@ -94,9 +94,10 @@ export const UserList = ({ users, group, refetchDetails, pending }: Props) => {
                 </HStack>
               </VStack>
             </HStack>
-            {(group.currentUserRole == GroupRoles.ADMIN || group.currentUserRole == GroupRoles.OWNER) &&
-              u.id !== group.owner.id &&
-              u.id !== currentUser?.id && (
+            {u.id !== group.owner.id &&
+              u.id !== currentUser?.id &&
+              (group.currentUserRole === GroupRoles.OWNER ||
+                (group.currentUserRole === GroupRoles.ADMIN && u.role !== GroupRoles.ADMIN)) && (
                 <Flex alignItems="center" p={2}>
                   <Menu>
                     <MenuButton as={IconButton} colorScheme="brand" icon={<FaChevronDown />} width="100%" />

--- a/src/pages/subjects/SubjectsPage.tsx
+++ b/src/pages/subjects/SubjectsPage.tsx
@@ -14,7 +14,7 @@ import {
   useToast,
   VStack
 } from '@chakra-ui/react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { FaEdit, FaFileCsv } from 'react-icons/fa'
 import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
@@ -38,6 +38,7 @@ export const SubjectsPage = () => {
   const [selectedMajor, setSelectedMajor] = useState<string>('all')
   const toast = useToast()
   const { loggedInUser } = useAuthContext()
+  const importModalRef = useRef<HTMLButtonElement>(null)
 
   const createSubjectMutation = useCreateSubjectMutation()
   const updateSubjectMutation = useUpdateSubjectMutation()
@@ -81,6 +82,12 @@ export const SubjectsPage = () => {
 
         <HStack>
           <UploadFileModalButton
+            initiatorButton={
+              <Button ref={importModalRef} colorScheme="green">
+                Tárgyak importálása
+              </Button>
+            }
+            initiatorButtonRef={importModalRef}
             mutation={importSubjectsmutation}
             modalTitle="Tárgyak importálása"
             confirmButtonText="Importálás"

--- a/src/pages/subjects/components/SubjectEditModalButton.tsx
+++ b/src/pages/subjects/components/SubjectEditModalButton.tsx
@@ -18,7 +18,7 @@ import {
   useDisclosure,
   useToast
 } from '@chakra-ui/react'
-import { ReactElement } from 'react'
+import { ReactElement, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { UseMutationResult } from 'react-query'
 import { KonziError } from '../../../api/model/error.model'
@@ -53,6 +53,7 @@ export const SubjectEditModalButton = ({
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { value: selectedMajors, getCheckboxProps, setValue: setSelectedMajors } = useCheckboxGroup()
   const toast = useToast()
+  const deleteSubjectRef = useRef<HTMLButtonElement>(null)
 
   const {
     register,
@@ -146,8 +147,12 @@ export const SubjectEditModalButton = ({
             <ModalFooter justifyContent="space-between">
               {previousData && deleteAction ? (
                 <ConfirmDialogButton
-                  buttonText="Törlés"
-                  buttonColorSchene="red"
+                  initiatorButton={
+                    <Button colorScheme="red" ref={deleteSubjectRef}>
+                      Törlés
+                    </Button>
+                  }
+                  initiatorButtonRef={deleteSubjectRef}
                   headerText="Biztosan törlöd a tárgyat?"
                   bodyText="Ezzel az tárgyhoz tartozó összes konzultáció is törlődik!"
                   confirmButtonText="Törlés"

--- a/src/pages/user/components/ProfileDetails.tsx
+++ b/src/pages/user/components/ProfileDetails.tsx
@@ -17,6 +17,7 @@ import {
   useBreakpointValue,
   useToast
 } from '@chakra-ui/react'
+import { useRef } from 'react'
 import { FaLock, FaSignOutAlt } from 'react-icons/fa'
 import { useAuthContext } from '../../../api/contexts/auth/useAuthContext'
 import { usePromoteUserMutation } from '../../../api/hooks/userMutationHooks'
@@ -38,6 +39,7 @@ type Props = {
 export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
   const { loggedInUser } = useAuthContext()
   const toast = useToast()
+  const promoteUserRef = useRef<HTMLButtonElement>(null)
   const { mutate: promoteUser } = usePromoteUserMutation(
     (data: UserModel) => {
       toast({ title: 'Felhasználó adminnak kinevezve!', status: 'success' })
@@ -101,10 +103,15 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
         <Flex flex={1} justifyContent="end">
           {loggedInUser?.isAdmin && !user.isAdmin && (
             <ConfirmDialogButton
+              initiatorButton={
+                <Button colorScheme="green" ref={promoteUserRef}>
+                  Adminná tétel
+                </Button>
+              }
+              initiatorButtonRef={promoteUserRef}
               headerText="Biztosan kinevezed adminnak?"
               bodyText="Biztosan kinevezed ezt a felhasználót adminnak? Ezt később csak az adatbázisba nyúlással lehet visszavonni!"
-              buttonText="Adminná tétel"
-              buttonColorSchene="green"
+              buttonColorScheme="green"
               confirmButtonText="Kinevezés"
               refuseButtonText="Mégsem"
               confirmAction={() => promoteUser(user.id)}


### PR DESCRIPTION
Refactored the layout of the buttons on the konzi details page. Admin/owner/presenter action buttons (edit, delete, modify file) have been grouped into a dropdown menu. 

I had to refactor the modal and popover components a lot, so they work with menuitems as well as buttons. The code is not nice, but it works xd

Some pictures:
(export button is disabled on the pics because it's not working on the backend yet)

As a participant, before the konzi starts:
![image](https://user-images.githubusercontent.com/13004605/218543282-914f0986-4d5c-4e7e-84a5-1c561c07c05d.png)

As a participant, after the konzi starts:
![image](https://user-images.githubusercontent.com/13004605/218543300-3f928ef6-6035-45da-a045-444eef0a8686.png)

As a presenter/owner, before or after the konzi starts:
![image](https://user-images.githubusercontent.com/13004605/218543320-5544432f-e2d1-44b3-b9df-ca542d14a65d.png)

As an admin, after the konzi starts:
![image](https://user-images.githubusercontent.com/13004605/218543332-1c09bd17-6d2c-4f76-a929-7a1e9f4fca34.png)

Also, I created a reusable component for downloading files from the backend. (Was previously used with the attachment download, now it's also used with the ics file)
