### PR TITLE
Plausible

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "framer-motion": "9.0.1",
     "js-cookie": "3.0.1",
     "lodash.debounce": "^4.0.8",
+    "plausible-tracker": "^0.3.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-helmet-async": "^1.3.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
+import Plausible from 'plausible-tracker'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'
@@ -8,11 +9,18 @@ import { BrowserRouter } from 'react-router-dom'
 import { AuthProvider } from './api/contexts/auth/AuthContext'
 import { App } from './App'
 import customTheme from './assets/theme'
+import { API_HOST } from './util/environment'
 import { initAxios, queryClient } from './util/query-client'
 
 initAxios()
 
 const root = createRoot(document.getElementById('root')!)
+
+const { enableAutoPageviews } = Plausible({
+  domain: API_HOST,
+  apiHost: 'https://visit.kir-dev.hu'
+})
+enableAutoPageviews()
 
 root.render(
   <React.StrictMode>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10112,6 +10112,7 @@ __metadata:
     js-cookie: 3.0.1
     lodash.debounce: ^4.0.8
     npm-run-all: 4.1.5
+    plausible-tracker: ^0.3.8
     prettier: 2.8.3
     react: 18.2.0
     react-dom: 18.2.0
@@ -11928,6 +11929,13 @@ __metadata:
   dependencies:
     find-up: ^3.0.0
   checksum: 5bac346b7c7c903613c057ae3ab722f320716199d753f4a7d053d38f2b5955460f3e6ab73b4762c62fd3e947f58e04f1343e92089e7bb6091c90877406fcd8c8
+  languageName: node
+  linkType: hard
+
+"plausible-tracker@npm:^0.3.8":
+  version: 0.3.8
+  resolution: "plausible-tracker@npm:0.3.8"
+  checksum: 066dd51586922fabbd70e4cfdeff77356669bf57852cd3cbc00d813938ed6637669ee615a1d7b865090550de61fc58bffb6e7c3e6d99f361ec7312d316033194
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To collect stats about the visitors 👀

With this config, it'll only track if the API_HOST is `konzi.vik.hk`, so production. To try it out, change the domain to `konzi.vik.hk` and add the `trackLocalhost: true` option.