### PR TITLE
long word fixes and footer fixes

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Prettify code
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           # This part is also where you can pass other options, for example:
           prettier_options: --write **/*.{js,md,ts,tsx}

--- a/src/assets/theme.ts
+++ b/src/assets/theme.ts
@@ -122,6 +122,7 @@ const customTheme = extendTheme({
   breakpoints: {
     // sm-2xl are the chakra defaults, added an extra breakpoint for 16+ inch full HD screens
     sm: '30em',
+    m: '39em',
     md: '48em',
     lg: '62em',
     xl: '80em',

--- a/src/components/commons/ConsultationListItem.tsx
+++ b/src/components/commons/ConsultationListItem.tsx
@@ -30,7 +30,9 @@ export const ConsultationListItem = ({ consultation, children, rightSmallText }:
         <MajorAvatar subject={consultation.subject} />
         <VStack flexGrow={1}>
           <Stack direction={['column', 'row']} justifyContent="space-between" width="100%">
-            <Heading size="md">{consultation.name}</Heading>
+            <Heading isTruncated maxWidth={{ base: '15rem', sm: '9rem', m: '15rem', md: '22rem', lg: '35rem' }} size="md">
+              {consultation.name}
+            </Heading>
             <Heading size={{ base: 'sm', md: 'md' }}>
               {generateDateText(consultation.startDate)} {generateTimeSpanText(consultation.startDate, consultation.endDate)}
             </Heading>

--- a/src/components/commons/Footer.tsx
+++ b/src/components/commons/Footer.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Flex, HStack, Image, Link, Text, useColorModeValue, VStack } from '@chakra-ui/react'
+import { Box, Container, Flex, HStack, Image, Link, Stack, Text, useColorModeValue, VStack } from '@chakra-ui/react'
 import { FC, MouseEvent } from 'react'
 import { FaEnvelope, FaFacebook, FaGithub, FaGlobe, FaHeart, FaInstagram } from 'react-icons/fa'
 import { Link as RRDLink } from 'react-router-dom'
@@ -18,8 +18,8 @@ export const Footer: FC = () => {
 
   return (
     <Box as="footer">
-      <Container py={8} as={Flex} justifyContent="space-evenly" direction={{ base: 'column', sm: 'row' }} maxW="6xl">
-        <HStack justify="center" spacing={5} mb={{ base: 12, sm: 0 }}>
+      <Container py={8} as={Flex} align="center" justifyContent="space-evenly" direction={{ base: 'column', m: 'row' }} maxW="6xl">
+        <HStack justify="center" spacing={{ base: 0, m: 5 }} mb={{ base: 12, m: 0 }}>
           <VStack>
             <ColorfulExternalLink centered url="https://vik.hk/" hoverColor={customTheme.colors.hk}>
               VIK Hallgatói Képviselet
@@ -55,7 +55,7 @@ export const Footer: FC = () => {
           </Link>
 
           <VStack>
-            <HStack spacing={2} justify="center">
+            <Stack direction={{ base: 'column', md: 'row' }} spacing={2} justify="center" align="center">
               <Text textAlign="center">Made with</Text>
               <FaHeart fontSize="1.5rem" color="red" />
               <Text textAlign="center">
@@ -64,7 +64,7 @@ export const Footer: FC = () => {
                   Kir-Dev
                 </ColorfulExternalLink>
               </Text>
-            </HStack>
+            </Stack>
             <Text textAlign="center">
               &copy; {new Date().getFullYear()} •{' '}
               <Link textAlign="center" as={RRDLink} to={PATHS.IMPRESSUM} _hover={{ color: customTheme.colors.kirDev }}>

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -99,7 +99,9 @@ export const ConsultationDetailsPage = () => {
         <VStack alignItems="flex-start" spacing={3} flexGrow={1}>
           <HStack>
             <FaMapMarkerAlt />
-            <Text> {consultation.location} </Text>
+            <Text isTruncated maxWidth={{ base: '18rem', sm: '15rem', m: '25rem', md: '35rem', lg: '48rem' }}>
+              {consultation.location}
+            </Text>
           </HStack>
           <HStack>
             <FaClock />

--- a/src/pages/groups/components/GroupList.tsx
+++ b/src/pages/groups/components/GroupList.tsx
@@ -57,7 +57,9 @@ export const GroupList = ({ groups, title, noGroupsMessage, loading = false, mt 
                   <HStack p={4}>
                     <Avatar size="md" name={g.name} src={''} />
                     <VStack flexGrow={1} align="flex-start">
-                      <Heading size="md">{g.name}</Heading>
+                      <Heading isTruncated maxWidth={{ base: '15rem', sm: '22rem', m: '30rem', md: '40rem', lg: '25rem' }} size="md">
+                        {g.name}
+                      </Heading>
 
                       <HStack justify="space-between" align="center">
                         <Text>{g.memberCount} tag</Text>


### PR DESCRIPTION
Probobly not the best solution, but should be good enough for now.
- closes #116 

Also fixes the prettier fail.

consultations:
![image](https://user-images.githubusercontent.com/65909866/220348888-7e2c687a-f89f-4053-8467-f761b57aa64f.png)

groups:
![image](https://user-images.githubusercontent.com/65909866/220348933-1de57a3b-d6d7-4b00-8deb-dbb606bee874.png)

consultation place:
![image](https://user-images.githubusercontent.com/65909866/220349200-d81382ec-75de-4be6-b1fc-479360cea70a.png)

mobile footer kirdev:
![image](https://user-images.githubusercontent.com/65909866/220349343-7fee7fe1-13bf-4bbe-8317-9be48ff323bc.png)
It's not perfectly in the middle but oh well...