### PR TITLE
Fix navbar breakpoint

### DIFF
--- a/src/components/navbar/MobileNav.tsx
+++ b/src/components/navbar/MobileNav.tsx
@@ -17,7 +17,7 @@ const MobileNav: FC<Props> = ({ onNavigate }) => {
   }, [isLoggedIn, loggedInUser])
 
   return (
-    <Stack display={{ md: 'none' }} fontWeight={700} fontSize="xl" ml={6} mb={6}>
+    <Stack display={{ lg: 'none' }} fontWeight={700} fontSize="xl" ml={6} mb={6}>
       {navItems.map((item) => (
         <HStack
           key={item.label}

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -20,7 +20,7 @@ export const Navbar: FC = () => {
     >
       <Box mx="auto" maxW="6xl" w="full" color={useColorModeValue('brand.500', 'white')}>
         <Flex h="4rem" w="full" px={4} py={2} align="center" justifyContent="space-between">
-          <Flex display={{ base: 'flex', md: 'none' }}>
+          <Flex display={{ base: 'flex', lg: 'none' }}>
             <IconButton
               onClick={onToggle}
               icon={isOpen ? <FaTimes size="1.5rem" /> : <FaBars size="1.5rem" />}
@@ -31,7 +31,7 @@ export const Navbar: FC = () => {
           <Heading fontFamily="title" as={Link} to={PATHS.INDEX} _hover={{ textDecoration: 'none' }}>
             Konzisite
           </Heading>
-          <Flex display={{ base: 'none', md: 'flex' }} flex={1} justifyContent="center">
+          <Flex display={{ base: 'none', lg: 'flex' }} flex={1} justifyContent="center">
             <DesktopNav />
           </Flex>
           <HStack ml={{ base: 0, md: 6 }}>


### PR DESCRIPTION
Navbar changes to the collapsable version at the chakra lg breakpoint (below ~991px), so menu items never go beyond the screen, not even on landscape mobile views. The final test be once it's in staging and we can test it on actual phones.

Closes #210 