### PR TITLE
Download reports

### DIFF
--- a/src/api/hooks/userMutationHooks.ts
+++ b/src/api/hooks/userMutationHooks.ts
@@ -36,6 +36,13 @@ export const usePromoteUserMutation = (onSuccess: (data: UserModel) => void, onE
 export const useUserReportMutation = () => {
   return useMutation<ArrayBuffer, ArrayBuffer>(
     async () =>
-      (await axios.get(`${PATHS.USERS}/report?startDate=1654540715000&endDate=1717699115000`, { responseType: 'arraybuffer' })).data
+      (await axios.get(`${PATHS.USERS}/report?startDate=1654540715000&endDate=1686323100000`, { responseType: 'arraybuffer' })).data
+  )
+}
+
+export const useAdminReportMutation = () => {
+  return useMutation<ArrayBuffer, ArrayBuffer>(
+    async () =>
+      (await axios.get(`${PATHS.USERS}/admin-report?startDate=1654540715000&endDate=1686323100000`, { responseType: 'arraybuffer' })).data
   )
 }

--- a/src/api/hooks/userMutationHooks.ts
+++ b/src/api/hooks/userMutationHooks.ts
@@ -12,6 +12,11 @@ export type FetchUserListMutationProps = {
   pageSize?: number
 }
 
+export type ReportDateRange = {
+  startDate: Date
+  endDate: Date
+}
+
 export const useFecthUserListMutation = (onError: (e: KonziError) => void) => {
   return useMutation<UserList, KonziError, FetchUserListMutationProps>(
     'fetchUsersMuatation',
@@ -34,15 +39,23 @@ export const usePromoteUserMutation = (onSuccess: (data: UserModel) => void, onE
 }
 
 export const useUserReportMutation = () => {
-  return useMutation<ArrayBuffer, ArrayBuffer>(
-    async () =>
-      (await axios.get(`${PATHS.USERS}/report?startDate=1654540715000&endDate=1686323100000`, { responseType: 'arraybuffer' })).data
+  return useMutation<ArrayBuffer, ArrayBuffer, ReportDateRange>(
+    async (dr: ReportDateRange) =>
+      (
+        await axios.get(`reports/user-report?startDate=${dr.startDate.getTime()}&endDate=${dr.endDate.getTime()}`, {
+          responseType: 'arraybuffer'
+        })
+      ).data
   )
 }
 
 export const useAdminReportMutation = () => {
-  return useMutation<ArrayBuffer, ArrayBuffer>(
-    async () =>
-      (await axios.get(`${PATHS.USERS}/admin-report?startDate=1654540715000&endDate=1686323100000`, { responseType: 'arraybuffer' })).data
+  return useMutation<ArrayBuffer, ArrayBuffer, ReportDateRange>(
+    async (dr: ReportDateRange) =>
+      (
+        await axios.get(`reports/admin-report?startDate=${dr.startDate.getTime()}&endDate=${dr.endDate.getTime()}`, {
+          responseType: 'arraybuffer'
+        })
+      ).data
   )
 }

--- a/src/api/hooks/userMutationHooks.ts
+++ b/src/api/hooks/userMutationHooks.ts
@@ -32,3 +32,10 @@ export const usePromoteUserMutation = (onSuccess: (data: UserModel) => void, onE
     onError
   })
 }
+
+export const useUserReportMutation = () => {
+  return useMutation<ArrayBuffer, ArrayBuffer>(
+    async () =>
+      (await axios.get(`${PATHS.USERS}/report?startDate=1654540715000&endDate=1717699115000`, { responseType: 'arraybuffer' })).data
+  )
+}

--- a/src/api/hooks/userMutationHooks.ts
+++ b/src/api/hooks/userMutationHooks.ts
@@ -38,24 +38,26 @@ export const usePromoteUserMutation = (onSuccess: (data: UserModel) => void, onE
   })
 }
 
-export const useUserReportMutation = () => {
+export const useUserReportMutation = (onSuccess: () => void) => {
   return useMutation<ArrayBuffer, ArrayBuffer, ReportDateRange>(
     async (dr: ReportDateRange) =>
       (
         await axios.get(`reports/user-report?startDate=${dr.startDate.getTime()}&endDate=${dr.endDate.getTime()}`, {
           responseType: 'arraybuffer'
         })
-      ).data
+      ).data,
+    { onSuccess }
   )
 }
 
-export const useAdminReportMutation = () => {
+export const useAdminReportMutation = (onSuccess: () => void) => {
   return useMutation<ArrayBuffer, ArrayBuffer, ReportDateRange>(
     async (dr: ReportDateRange) =>
       (
         await axios.get(`reports/admin-report?startDate=${dr.startDate.getTime()}&endDate=${dr.endDate.getTime()}`, {
           responseType: 'arraybuffer'
         })
-      ).data
+      ).data,
+    { onSuccess }
   )
 }

--- a/src/components/commons/DownloadFileFromServerButton.tsx
+++ b/src/components/commons/DownloadFileFromServerButton.tsx
@@ -3,21 +3,21 @@ import { RefObject, useEffect, useRef } from 'react'
 import { UseMutationResult } from 'react-query'
 import { HasChildren } from '../../util/react-types.util'
 
-type Props = {
+type Props<T> = {
   buttonRef: RefObject<HTMLButtonElement>
-  downloadMutation: UseMutationResult<ArrayBuffer, ArrayBuffer, number, unknown>
-  entityId: number
+  downloadMutation: UseMutationResult<ArrayBuffer, ArrayBuffer, T, unknown>
+  params: T
   fileName: string
 } & HasChildren
 
-export const DownloadFileFromServerButton = ({ buttonRef, downloadMutation, entityId, children, fileName }: Props) => {
+export const DownloadFileFromServerButton = <T,>({ buttonRef, downloadMutation, params, children, fileName }: Props<T>) => {
   const anchorRef = useRef<HTMLAnchorElement>(null)
   const toast = useToast()
 
   useEffect(() => {
     if (buttonRef?.current) {
       buttonRef.current.onclick = () => {
-        downloadMutation.mutate(entityId, {
+        downloadMutation.mutate(params, {
           onSuccess: (rawFile: ArrayBuffer) => {
             const blob = new Blob([rawFile])
             if (anchorRef.current) {

--- a/src/components/commons/DownloadFileFromServerButton.tsx
+++ b/src/components/commons/DownloadFileFromServerButton.tsx
@@ -35,7 +35,8 @@ export const DownloadFileFromServerButton = <T,>({ buttonRef, downloadMutation, 
         })
       }
     }
-  }, [])
+  }, [downloadMutation])
+
   return (
     <>
       <a ref={anchorRef} download={fileName} hidden />

--- a/src/pages/consultations/ConsultationDetailsPage.tsx
+++ b/src/pages/consultations/ConsultationDetailsPage.tsx
@@ -136,9 +136,9 @@ export const ConsultationDetailsPage = () => {
           )}
           {((new Date() > new Date(consultation.startDate) && isParticipant) || isPresenter || isOwner || isAdmin) &&
             consultation.fileName && (
-              <DownloadFileFromServerButton
+              <DownloadFileFromServerButton<number>
                 buttonRef={downloadFileRef}
-                entityId={consultation.id}
+                params={consultation.id}
                 fileName={consultation.fileName}
                 downloadMutation={downloadFileMutation}
               >
@@ -164,12 +164,12 @@ export const ConsultationDetailsPage = () => {
                 </Tooltip>
               </DownloadFileFromServerButton>
             )}
-          {new Date() < new Date(consultation.startDate) && ( // TODO remove comment when the backend is ready
-            <DownloadFileFromServerButton
+          {new Date() < new Date(consultation.startDate) && (
+            <DownloadFileFromServerButton<number>
               buttonRef={exportKonziRef}
               downloadMutation={exportKonziMutation}
               fileName={`konzultacio_${consultation.id}.ics`}
-              entityId={consultation.id}
+              params={consultation.id}
             >
               <Button ref={exportKonziRef} w="100%" colorScheme="green">
                 Exportálás naptárba

--- a/src/pages/user/components/ProfileDetails.tsx
+++ b/src/pages/user/components/ProfileDetails.tsx
@@ -89,9 +89,9 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
             />
           )}
           {onLogoutPressed && (
-            <Stack direction={['column', 'column', 'row']} w={['100%', 'inherit']}>
+            <Stack direction="column" w={['100%', '100%', 'inherit']}>
               <ReportModal />
-              <Button w={['100%', 'inherit']} colorScheme="brand" rightIcon={<FaSignOutAlt />} onClick={() => onLogoutPressed()}>
+              <Button w={['100%', '100%', 'inherit']} colorScheme="brand" rightIcon={<FaSignOutAlt />} onClick={() => onLogoutPressed()}>
                 Kijelentkezés
               </Button>
             </Stack>

--- a/src/pages/user/components/ProfileDetails.tsx
+++ b/src/pages/user/components/ProfileDetails.tsx
@@ -18,16 +18,16 @@ import {
 import { useRef } from 'react'
 import { FaAt, FaSignOutAlt } from 'react-icons/fa'
 import { useAuthContext } from '../../../api/contexts/auth/useAuthContext'
-import { useAdminReportMutation, usePromoteUserMutation, useUserReportMutation } from '../../../api/hooks/userMutationHooks'
+import { usePromoteUserMutation } from '../../../api/hooks/userMutationHooks'
 import { KonziError } from '../../../api/model/error.model'
 import { UserModel } from '../../../api/model/user.model'
 import { ConfirmDialogButton } from '../../../components/commons/ConfirmDialogButton'
-import { DownloadFileFromServerButton } from '../../../components/commons/DownloadFileFromServerButton'
 import { generateToastParams } from '../../../util/generateToastParams'
 import { UserDetails } from '../types/UserDetails'
 import { ParticipationPanel } from './panels/ParticipationPanel'
 import { PresentationPanel } from './panels/PresentationPanel'
 import { RequestPanel } from './panels/RequestPanel'
+import { ReportModal } from './ReportModal'
 import { UserStatCard } from './UserStatCard'
 
 type Props = {
@@ -46,10 +46,6 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
     },
     (e: KonziError) => toast(generateToastParams(e))
   )
-  const getUserReportMutation = useUserReportMutation()
-  const userReportRef = useRef<HTMLButtonElement>(null)
-  const getAdminReportMutation = useAdminReportMutation()
-  const adminReportRef = useRef<HTMLButtonElement>(null)
 
   return (
     <Box>
@@ -75,7 +71,7 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
             </VStack>
           </Stack>
         </HStack>
-        <Flex flex={1} justifyContent="end">
+        <Flex flex={1} justifyContent={['center', 'center', 'end']}>
           {loggedInUser?.isAdmin && !user.isAdmin && (
             <ConfirmDialogButton
               initiatorButton={
@@ -93,31 +89,13 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
             />
           )}
           {onLogoutPressed && (
-            <Button colorScheme="brand" rightIcon={<FaSignOutAlt />} onClick={() => onLogoutPressed()}>
-              Kijelentkezés
-            </Button>
+            <Stack direction={['column', 'column', 'row']} w={['100%', 'inherit']}>
+              <ReportModal />
+              <Button w={['100%', 'inherit']} colorScheme="brand" rightIcon={<FaSignOutAlt />} onClick={() => onLogoutPressed()}>
+                Kijelentkezés
+              </Button>
+            </Stack>
           )}
-          <DownloadFileFromServerButton<void>
-            buttonRef={userReportRef}
-            downloadMutation={getUserReportMutation}
-            fileName={`report.pdf`}
-            params={undefined}
-          >
-            <Button isLoading={getUserReportMutation.isLoading} ref={userReportRef} w="100%" colorScheme="green">
-              Report
-            </Button>
-          </DownloadFileFromServerButton>
-
-          <DownloadFileFromServerButton<void>
-            buttonRef={adminReportRef}
-            downloadMutation={getAdminReportMutation}
-            fileName={`admin_report.pdf`}
-            params={undefined}
-          >
-            <Button isLoading={getAdminReportMutation.isLoading} ref={adminReportRef} w="100%" colorScheme="green">
-              Admin Report
-            </Button>
-          </DownloadFileFromServerButton>
         </Flex>
       </HStack>
       <UserStatCard stats={user.stats} />

--- a/src/pages/user/components/ProfileDetails.tsx
+++ b/src/pages/user/components/ProfileDetails.tsx
@@ -18,7 +18,7 @@ import {
 import { useRef } from 'react'
 import { FaAt, FaSignOutAlt } from 'react-icons/fa'
 import { useAuthContext } from '../../../api/contexts/auth/useAuthContext'
-import { usePromoteUserMutation, useUserReportMutation } from '../../../api/hooks/userMutationHooks'
+import { useAdminReportMutation, usePromoteUserMutation, useUserReportMutation } from '../../../api/hooks/userMutationHooks'
 import { KonziError } from '../../../api/model/error.model'
 import { UserModel } from '../../../api/model/user.model'
 import { ConfirmDialogButton } from '../../../components/commons/ConfirmDialogButton'
@@ -48,6 +48,8 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
   )
   const getUserReportMutation = useUserReportMutation()
   const userReportRef = useRef<HTMLButtonElement>(null)
+  const getAdminReportMutation = useAdminReportMutation()
+  const adminReportRef = useRef<HTMLButtonElement>(null)
 
   return (
     <Box>
@@ -101,8 +103,19 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
             fileName={`report.pdf`}
             params={undefined}
           >
-            <Button ref={userReportRef} w="100%" colorScheme="green">
+            <Button isLoading={getUserReportMutation.isLoading} ref={userReportRef} w="100%" colorScheme="green">
               Report
+            </Button>
+          </DownloadFileFromServerButton>
+
+          <DownloadFileFromServerButton<void>
+            buttonRef={adminReportRef}
+            downloadMutation={getAdminReportMutation}
+            fileName={`admin_report.pdf`}
+            params={undefined}
+          >
+            <Button isLoading={getAdminReportMutation.isLoading} ref={adminReportRef} w="100%" colorScheme="green">
+              Admin Report
             </Button>
           </DownloadFileFromServerButton>
         </Flex>

--- a/src/pages/user/components/ProfileDetails.tsx
+++ b/src/pages/user/components/ProfileDetails.tsx
@@ -18,10 +18,11 @@ import {
 import { useRef } from 'react'
 import { FaAt, FaSignOutAlt } from 'react-icons/fa'
 import { useAuthContext } from '../../../api/contexts/auth/useAuthContext'
-import { usePromoteUserMutation } from '../../../api/hooks/userMutationHooks'
+import { usePromoteUserMutation, useUserReportMutation } from '../../../api/hooks/userMutationHooks'
 import { KonziError } from '../../../api/model/error.model'
 import { UserModel } from '../../../api/model/user.model'
 import { ConfirmDialogButton } from '../../../components/commons/ConfirmDialogButton'
+import { DownloadFileFromServerButton } from '../../../components/commons/DownloadFileFromServerButton'
 import { generateToastParams } from '../../../util/generateToastParams'
 import { UserDetails } from '../types/UserDetails'
 import { ParticipationPanel } from './panels/ParticipationPanel'
@@ -45,6 +46,8 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
     },
     (e: KonziError) => toast(generateToastParams(e))
   )
+  const getUserReportMutation = useUserReportMutation()
+  const userReportRef = useRef<HTMLButtonElement>(null)
 
   return (
     <Box>
@@ -92,6 +95,16 @@ export const ProfileDetails = ({ user, onLogoutPressed }: Props) => {
               Kijelentkezés
             </Button>
           )}
+          <DownloadFileFromServerButton<void>
+            buttonRef={userReportRef}
+            downloadMutation={getUserReportMutation}
+            fileName={`report.pdf`}
+            params={undefined}
+          >
+            <Button ref={userReportRef} w="100%" colorScheme="green">
+              Report
+            </Button>
+          </DownloadFileFromServerButton>
         </Flex>
       </HStack>
       <UserStatCard stats={user.stats} />

--- a/src/pages/user/components/ReportModal.tsx
+++ b/src/pages/user/components/ReportModal.tsx
@@ -26,15 +26,16 @@ import { formatDate, getEndOfSemester, getStartOfSemester } from '../../../util/
 
 export const ReportModal = () => {
   const { loggedInUser } = useAuthContext()
+  const isAdmin = loggedInUser?.isAdmin
   const [largeScreen] = useMediaQuery('(min-width: 48em)')
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [startDate, setStartDate] = useState(getStartOfSemester())
   const [endDate, setEndDate] = useState(getEndOfSemester())
   const [adminReport, setAdminReport] = useState(false)
 
-  const getUserReportMutation = useUserReportMutation()
+  const getUserReportMutation = useUserReportMutation(onClose)
   const userReportRef = useRef<HTMLButtonElement>(null)
-  const getAdminReportMutation = useAdminReportMutation()
+  const getAdminReportMutation = useAdminReportMutation(onClose)
   const adminReportRef = useRef<HTMLButtonElement>(null)
 
   const startDateError = startDate >= endDate
@@ -59,7 +60,7 @@ export const ReportModal = () => {
           <ModalBody pb={6}>
             <VStack alignItems="flex-start">
               <Text>HK-s ösztöndíjakhoz itt tudsz riport generálni az általad tartott konzultációkról.</Text>
-              {loggedInUser?.isAdmin && (
+              {isAdmin && (
                 <Text textAlign="justify">
                   Adminként van lehetőséged olyan riport generálására, melyen az összes konzi szereplni fog, amit az adott időtartamban
                   tartottak.
@@ -86,7 +87,7 @@ export const ReportModal = () => {
                   {endDateError && <FormHelperText color="red.500">Csak múltbeli konzikról lehet riportot generálni!</FormHelperText>}
                 </Flex>
               </FormControl>
-              {loggedInUser?.isAdmin && (
+              {isAdmin && (
                 <Checkbox colorScheme="green" isChecked={adminReport} onChange={(e) => setAdminReport(e.target.checked)}>
                   Admin riport
                 </Checkbox>
@@ -107,7 +108,7 @@ export const ReportModal = () => {
               >
                 <Button
                   isLoading={getAdminReportMutation.isLoading}
-                  isDisabled={startDateError || endDateError || !loggedInUser?.isAdmin}
+                  isDisabled={startDateError || endDateError || !isAdmin}
                   ref={adminReportRef}
                   colorScheme="green"
                 >

--- a/src/pages/user/components/ReportModal.tsx
+++ b/src/pages/user/components/ReportModal.tsx
@@ -1,0 +1,139 @@
+import {
+  Button,
+  Checkbox,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
+  useDisclosure,
+  useMediaQuery
+} from '@chakra-ui/react'
+import { ChangeEvent, useRef, useState } from 'react'
+import { useAuthContext } from '../../../api/contexts/auth/useAuthContext'
+import { ReportDateRange, useAdminReportMutation, useUserReportMutation } from '../../../api/hooks/userMutationHooks'
+import { DownloadFileFromServerButton } from '../../../components/commons/DownloadFileFromServerButton'
+import { formatDate, getEndOfSemester, getStartOfSemester } from '../../../util/dateHelper'
+
+export const ReportModal = () => {
+  const { loggedInUser } = useAuthContext()
+  const [largeScreen] = useMediaQuery('(min-width: 48em)')
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [startDate, setStartDate] = useState(getStartOfSemester())
+  const [endDate, setEndDate] = useState(getEndOfSemester())
+  const [adminReport, setAdminReport] = useState(false)
+
+  const getUserReportMutation = useUserReportMutation()
+  const userReportRef = useRef<HTMLButtonElement>(null)
+  const getAdminReportMutation = useAdminReportMutation()
+  const adminReportRef = useRef<HTMLButtonElement>(null)
+
+  const startDateError = startDate >= endDate
+  const endDateError = endDate > new Date()
+
+  const onEndDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const date = new Date(e.target.value)
+    date.setHours(23, 59, 59, 999)
+    setEndDate(date)
+  }
+
+  return (
+    <>
+      <Button colorScheme="green" onClick={onOpen}>
+        Riport generálása
+      </Button>
+      <Modal isCentered={largeScreen} motionPreset="slideInBottom" isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Riport generálása</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <VStack alignItems="flex-start">
+              <Text>HK-s ösztöndíjakhoz itt tudsz riport generálni az általad tartott konzultációkról.</Text>
+              {loggedInUser?.isAdmin && (
+                <Text textAlign="justify">
+                  Adminként van lehetőséged olyan riport generálására, melyen az összes konzi szereplni fog, amit az adott időtartamban
+                  tartottak.
+                </Text>
+              )}
+              <FormControl>
+                <FormLabel>Időtartam kezdete</FormLabel>
+                <Input
+                  type="date"
+                  onChange={(e) => setStartDate(new Date(e.target.value))}
+                  value={formatDate(startDate)}
+                  max={formatDate(new Date(Date.now() - 24 * 60 * 60 * 1000))}
+                />
+
+                <Flex justifyContent="flex-end">
+                  {startDateError && <FormHelperText color="red.500">Érvénytelen időtartam!</FormHelperText>}
+                </Flex>
+              </FormControl>
+              <FormControl>
+                <FormLabel>Időtartam vége</FormLabel>
+                <Input type="date" onChange={onEndDateChange} value={formatDate(endDate)} max={formatDate(new Date())} />
+
+                <Flex justifyContent="flex-end">
+                  {endDateError && <FormHelperText color="red.500">Csak múltbeli konzikról lehet riportot generálni!</FormHelperText>}
+                </Flex>
+              </FormControl>
+              {loggedInUser?.isAdmin && (
+                <Checkbox colorScheme="green" isChecked={adminReport} onChange={(e) => setAdminReport(e.target.checked)}>
+                  Admin riport
+                </Checkbox>
+              )}
+            </VStack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button onClick={onClose} mr={3}>
+              Mégse
+            </Button>
+            {adminReport ? (
+              <DownloadFileFromServerButton<ReportDateRange>
+                buttonRef={adminReportRef}
+                downloadMutation={getAdminReportMutation}
+                fileName={`konzisite_admin_riport.pdf`}
+                params={{ startDate, endDate }}
+              >
+                <Button
+                  isLoading={getAdminReportMutation.isLoading}
+                  isDisabled={startDateError || endDateError || !loggedInUser?.isAdmin}
+                  ref={adminReportRef}
+                  colorScheme="green"
+                >
+                  Generálás
+                </Button>
+              </DownloadFileFromServerButton>
+            ) : (
+              <DownloadFileFromServerButton<ReportDateRange>
+                buttonRef={userReportRef}
+                downloadMutation={getUserReportMutation}
+                fileName={`konzisite_report.pdf`}
+                params={{ startDate, endDate }}
+              >
+                <Button
+                  isLoading={getUserReportMutation.isLoading}
+                  isDisabled={startDateError || endDateError}
+                  ref={userReportRef}
+                  colorScheme="green"
+                >
+                  Generálás
+                </Button>
+              </DownloadFileFromServerButton>
+            )}
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/src/util/dateHelper.ts
+++ b/src/util/dateHelper.ts
@@ -41,3 +41,38 @@ export const formatTime = (date: Date) => {
 
   return [hour, minute].join(':')
 }
+
+export const getStartOfSemester = (): Date => {
+  const date = new Date()
+  // If it's not July yet, the user is probably interested in the fall semester
+  if (date.getMonth() < 6) {
+    // 1st of July of the previous year
+    date.setFullYear(date.getFullYear() - 1)
+    date.setMonth(6)
+    date.setDate(1)
+    date.setHours(0, 0, 0, 0)
+  } else {
+    // 1st of February of the same year
+    date.setMonth(1)
+    date.setDate(1)
+    date.setHours(0, 0, 0, 0)
+  }
+  return date
+}
+
+export const getEndOfSemester = (): Date => {
+  const date = new Date()
+  // If it's not July yet, the user is probably interested in the fall semester
+  if (date.getMonth() < 6) {
+    // 31st of January of the same year
+    date.setMonth(0)
+    date.setDate(31)
+    date.setHours(23, 59, 59, 999)
+  } else {
+    // 30th of June of the same year
+    date.setMonth(5)
+    date.setDate(30)
+    date.setHours(23, 59, 59, 999)
+  }
+  return date
+}


### PR DESCRIPTION
Closes #249 

Added a modal where a user can download a report of their consultations. The time range of the report can be selected by the user. Admins can download admin reports, as well.